### PR TITLE
chore: migrate workflows from npm to yarn

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -39,13 +39,13 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: npm ci
+        run: yarn install --frozen-lockfile
 
       - name: Build package
-        run: npm run build
+        run: yarn build
 
       - name: Run tests
-        run: npm test
+        run: yarn test
 
       - name: Get current version
         id: current_version
@@ -63,8 +63,8 @@ jobs:
           if [ "$BUMP_TYPE" = "none" ]; then
             NEW_VERSION="$CURRENT_VERSION"
           else
-            # Use npm version to calculate new version
-            NEW_VERSION=$(npm version $BUMP_TYPE --no-git-tag-version --dry-run | sed 's/v//')
+            # Use yarn version to calculate new version
+            NEW_VERSION=$(yarn version $BUMP_TYPE --no-git-tag-version --dry-run | sed 's/v//')
           fi
 
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
@@ -73,7 +73,7 @@ jobs:
       - name: Update package.json version
         if: inputs.version_bump != 'none'
         run: |
-          npm version ${{ inputs.version_bump }} --no-git-tag-version
+          yarn version ${{ inputs.version_bump }} --no-git-tag-version
           echo "Updated package.json to version ${{ steps.new_version.outputs.new_version }}"
 
       - name: Generate changelog
@@ -87,7 +87,7 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add package.json package-lock.json
+          git add package.json yarn.lock
           git commit -m "chore: bump version to ${{ steps.new_version.outputs.new_version }}" || exit 0
           git tag -a "v${{ steps.new_version.outputs.new_version }}" -m "Release v${{ steps.new_version.outputs.new_version }}"
           git push origin HEAD:master
@@ -110,7 +110,7 @@ jobs:
         if: inputs.dry_run == false
         run: |
           # Publish with provenance for supply chain security
-          npm publish --provenance --access public
+          yarn publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -24,19 +24,19 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: npm ci
+        run: yarn install --frozen-lockfile
 
       - name: Build package
-        run: npm run build
+        run: yarn build
 
       - name: Run tests
-        run: npm test
+        run: yarn test
 
       - name: Publish to npm
         run: |
           # Publish with provenance for supply chain security
           # The --access public flag is needed for scoped packages
-          npm publish --provenance --access public
+          yarn publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
- Updated manual-release.yml and publish-npm.yml to use yarn for dependency installation, building, testing, and publishing.
- This change enhances consistency across workflows and aligns with the project's shift towards yarn.