### PR TITLE
fix: enable chore commits to trigger releases

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -41,7 +41,7 @@
         {
           "type": "chore",
           "section": "Miscellaneous Chores",
-          "hidden": true
+          "hidden": false
         },
         {
           "type": "refactor",


### PR DESCRIPTION
This PR fixes the issue where Release Please was skipping releases because chore commits were hidden.

Changes:
- Changed chore commits from hidden to visible in release-please config
- This allows chore commits to trigger patch version bumps
- Fixes issue where Release Please was skipping releases

This should resolve the auto-release functionality.