### PR TITLE
fix: update Node.js version to 20 in workflows

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies


### PR DESCRIPTION
This PR fixes the Node.js compatibility issue in CI workflows.

Changes:
- Updated publish-npm.yml to use Node.js 20 instead of 18
- Updated manual-release.yml to use Node.js 20 instead of 18
- Fixes compatibility issue with glob@11.0.3 which requires Node.js 20+
- This should resolve the yarn install failures in CI

The workflows were failing because glob@11.0.3 requires Node.js 20 or higher, but the workflows were using Node.js 18.