### PR TITLE
fix: use npm publish instead of yarn publish

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -110,7 +110,7 @@ jobs:
         if: inputs.dry_run == false
         run: |
           # Publish with provenance for supply chain security
-          yarn publish --provenance --access public
+          npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           # Publish with provenance for supply chain security
           # The --access public flag is needed for scoped packages
-          yarn publish --provenance --access public
+          npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This PR fixes the npm publishing issue by using npm publish instead of yarn publish.

Changes:
- Changed publish-npm.yml to use npm publish instead of yarn publish
- Changed manual-release.yml to use npm publish instead of yarn publish
- yarn publish tries to bump version automatically, but we want to publish current version
- npm publish publishes the version already in package.json without version bumping
- This should resolve the 'Not found' error when publishing to npm