### PR TITLE
fix: switch to NPM_TOKEN and add release debugging

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -112,7 +112,7 @@ jobs:
           # Publish with provenance for supply chain security
           npm publish --provenance --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Dry run summary
         if: inputs.dry_run == true

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -14,6 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     concurrency: npm-publish
     steps:
+      - name: Debug release info
+        run: |
+          echo "Release event: ${{ github.event_name }}"
+          echo "Release action: ${{ github.event.action }}"
+          echo "Release tag: ${{ github.event.release.tag_name }}"
+          echo "Release name: ${{ github.event.release.name }}"
+          echo "Release published: ${{ github.event.release.published_at }}"
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -38,7 +46,7 @@ jobs:
           # The --access public flag is needed for scoped packages
           npm publish --provenance --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Verify publication
         run: |


### PR DESCRIPTION
This PR fixes the npm publishing authentication and adds debugging for release events.

Changes:
- Changed from GITHUB_TOKEN to NPM_TOKEN for npm authentication
- Added debug logging to understand why release events aren't triggering
- This should resolve the OIDC authentication issues
- NPM_TOKEN is more reliable than OIDC for npm publishing

The OIDC setup was causing 404 errors, so switching to a traditional NPM_TOKEN should be more reliable.