### PR TITLE
chore: update workflow documentation

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -5,6 +5,9 @@ on:
     types: [published]
   workflow_dispatch:
 
+# This workflow publishes the package to npm when a GitHub Release is published
+# It automatically triggers on release:published events
+
 permissions:
   contents: read
   id-token: write


### PR DESCRIPTION
This PR tests the complete automation flow.

Changes:
- Added comment explaining that publish-npm.yml triggers on release:published events
- This helps clarify the automation flow

This should trigger:
1. Release Please to create a Release PR
2. Auto-merge the PR
3. Create GitHub Release
4. Trigger publish-npm.yml automatically
5. Publish to npm