### PR TITLE
fix: trigger publish workflow directly from release-please

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -6,7 +6,6 @@ on:
   workflow_dispatch:
 
 # This workflow publishes the package to npm when a GitHub Release is published
-# It automatically triggers on release:published events
 
 permissions:
   contents: read

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,3 +40,17 @@ jobs:
         run: |
           echo "Release created: ${{ steps.release.outputs.tag_name }}"
           echo "Upload URL: ${{ steps.release.outputs.upload_url }}"
+
+      - name: Trigger Publish Workflow
+        if: steps.release.outputs.release_created == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Trigger the publish workflow
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'publish-npm.yml',
+              ref: 'master'
+            });
+            console.log('Triggered publish-npm.yml workflow');


### PR DESCRIPTION
This PR fixes the auto-trigger issue for publish-npm.yml workflow.

**Problem:**
- GitHub Actions doesn't trigger workflows on releases created by the same repository's GitHub Actions bot
- This prevents publish-npm.yml from triggering automatically when Release Please creates releases
- Manual releases work fine, but automated releases don't trigger the publish workflow

**Solution:**
- Added step to trigger publish-npm.yml workflow directly when Release Please creates a release
- Uses actions/github-script to programmatically trigger the publish workflow
- This ensures the complete automation flow works end-to-end

**Changes:**
- Updated release-please.yml to trigger publish-npm.yml when release is created
- This bypasses the GitHub Actions limitation and ensures automatic publishing