### PR TITLE
fix: add actions: write permission to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   release-please:


### PR DESCRIPTION
This PR fixes the permission issue that was preventing the release-please workflow from triggering the publish workflow.

**Problem:**
- The release-please workflow was failing to trigger publish-npm.yml with 403 'Resource not accessible by integration' error
- This was because the GITHUB_TOKEN didn't have the necessary permissions to trigger other workflows

**Solution:**
- Added actions: write permission to the release-please workflow
- This allows the workflow to trigger other workflows programmatically

**Changes:**
- Updated release-please.yml permissions to include actions: write
- This should fix the complete automation flow